### PR TITLE
Command update required for new ecm firmware.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ iocs/test*
 *~
 .idea
 cmake-build-debug/
+.vscode

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -12,9 +12,9 @@ SUPPORT=       /dls_sw/prod/R3.14.12.7/support
 WORK=          /dls_sw/work/R3.14.12.7/support
 
 # External module definitions
-ASYN=       $(SUPPORT)/asyn/4-41
-ASYNAID=    $(SUPPORT)/asynaid/2-11
-MOTOR=      $(SUPPORT)/motor/7-0dls8
+ASYN=       $(SUPPORT)/asyn/4-41dls2
+ASYNAID=    $(SUPPORT)/asynaid/2-12
+MOTOR=      $(SUPPORT)/motor/7-0dls9-1
 
 # EPICS_BASE usually appears last so other apps can override stuff:
 EPICS_BASE=/dls_sw/epics/R3.14.12.7/base

--- a/smaractEcmApp/src/ecmController.cpp
+++ b/smaractEcmApp/src/ecmController.cpp
@@ -152,7 +152,34 @@ asynStatus EcmController::poll()
             if (ok)
             {
                 // Everything ok, update parameters
-                paramVersion = version + info_header_len;
+
+                std::string str_version(version);
+
+                // // Current compiler version not supporting regex!
+                // const std::regex pattern("[a-zA-Z\s:]{15,}");
+                // str_version = std::regex_replace(str_version, pattern, ", ");
+
+                std::string str1 = "Device Serial Number: ";
+                std::string str2 = "Device Product Code: ";
+                std::string str3 = "Firmware Version: ";
+                
+                size_t pos0 = str_version.find(str1);
+                size_t pos1 = str_version.find(str2, pos0);
+                size_t pos2 = str_version.find(str3, pos1);
+                
+                size_t token1_begin = pos0 + str1.length();
+                std::string serial_number = str_version.substr(token1_begin, pos1 - token1_begin);
+                
+                size_t token2_begin = pos1 + str2.length();
+                std::string product_code = str_version.substr(token2_begin, pos2 - token2_begin);
+
+                size_t token3_begin = pos2 + str3.length();
+                std::string firmware = str_version.substr(token3_begin, std::string::npos - token3_begin);
+
+                std::string stripped_version = "sn:" + serial_number + ",#:" + product_code + ",f:" + firmware;
+                
+                paramVersion = stripped_version;
+                
                 paramConnected = true;
             }
         }


### PR DESCRIPTION
Replace command %info version by %info device, and extract strings.
Update support module dependencies.